### PR TITLE
Add medi-rs-macros crate with derive macros and async dependency support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ RUN usermod -u $UID vscode
 USER vscode
 
 # Install rust version and components
-RUN rustup default 1.86
+RUN rustup default 1.87.0
 RUN rustup target add x86_64-unknown-linux-musl
 RUN rustup component add rustfmt
 RUN rustup component add clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: lcov.info
-
-      - name: Dry run publish crate
-        run: just publish 0.0.0 --token ${{ secrets.CRATESIO_TOKEN }} --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +80,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,12 +209,23 @@ dependencies = [
 
 [[package]]
 name = "medi-rs"
-version = "0.0.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "futures",
+ "medi-rs-macros",
  "rand",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "medi-rs-macros"
+version = "1.0.0"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -183,6 +294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,18 +310,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -270,6 +387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,21 @@
 [package]
 name = "medi-rs"
 description = "A yet another mediator library for Rust"
-version = "1.0.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+readme.workspace = true
+
+[workspace.package]
 edition = "2024"
+version = "1.0.0"
 authors = ["Burak <burak.kizilkaya@outlook.com>"]
-license = "MIT"
 homepage = "https://github.com/klab365/medi-rs"
 repository = "https://github.com/klab365/medi-rs"
+license = "MIT"
 keywords = ["mediator"]
 readme = "Readme.md"
 
@@ -29,19 +38,3 @@ medi-rs-macros = { version = "1.0.0", path = "src-macros", optional = true }
 rand = "0.8.5"
 anyhow = "1.0.98"
 async-trait = "0.1.88"
-
-[package.metadata.release]
-
-[workspace.metadata.release]
-# Release all packages in the workspace together
-shared-version = true
-# Don't create individual tags for each package
-tag-name = "v{{version}}"
-# Push changes and tags to remote
-push = true
-# Create a GitHub release
-release = true
-# Sign tags
-sign-tag = false
-# Sign commits
-sign-commit = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "medi-rs"
 description = "A yet another mediator library for Rust"
-version = "0.0.0"
+version = "1.0.0"
 edition = "2024"
 authors = ["Burak <burak.kizilkaya@outlook.com>"]
 license = "MIT"
@@ -10,12 +10,38 @@ repository = "https://github.com/klab365/medi-rs"
 keywords = ["mediator"]
 readme = "Readme.md"
 
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
+[workspace]
+members = [".", "src-macros"]
+
+[features]
+default = ["medi-rs-macros"]
 
 [dependencies]
+futures = "0.3.31"
 thiserror = "1.0.64"
 tokio = {version = "1.40.0", features = ["full"]}
+medi-rs-macros = { version = "1.0.0", path = "src-macros", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
 anyhow = "1.0.98"
+async-trait = "0.1.88"
 
+[package.metadata.release]
+
+[workspace.metadata.release]
+# Release all packages in the workspace together
+shared-version = true
+# Don't create individual tags for each package
+tag-name = "v{{version}}"
+# Push changes and tags to remote
+push = true
+# Create a GitHub release
+release = true
+# Sign tags
+sign-tag = false
+# Sign commits
+sign-commit = false

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,12 @@ This file present the software status in form of a "Changelog".
 
 This document is valid within the scope of the work for all projects.
 
+## 1.2.0
+
+### Added
+
+* Add macros for IntoCommand, FromResource, etc. to simplify command and resource handling (see readme).
+
 ## 1.1.0
 
 ### Changed

--- a/Justfile
+++ b/Justfile
@@ -19,14 +19,16 @@ build *ARGS='':
 # publish
 publish version='0.0.0' *ARGS='':
     echo "Building for release V{{ version }}"
-    # Update version in root Cargo.toml
-    sed -i 's/^version = ".*"/version = "{{version}}"/' Cargo.toml
-    # Update version in src-macros/Cargo.toml
-    sed -i 's/^version = ".*"/version = "{{version}}"/' src-macros/Cargo.toml
-    # Update dependency version for medi-rs-macros in root Cargo.toml
-    sed -i 's/medi-rs-macros = { version *= *"[^"]*"/medi-rs-macros = { version = "{{version}}"/g' Cargo.toml
+    # Update workspace version in [workspace.package] section
+    sed -i '/^\[workspace\.package\]/,/^\[/ s/^version = ".*"/version = "{{version}}"/' Cargo.toml
+    # Update dependency version for medi-rs-macros in root Cargo.toml to use published version
+    sed -i 's/medi-rs-macros = { path = "src-macros"/medi-rs-macros = { version = "{{version}}", path = "src-macros"/g' Cargo.toml
 
+    # Publish macro crate first
     {{ CMD }} publish --package medi-rs-macros --allow-dirty {{ARGS}}
+    # Wait a moment for crates.io to process
+    sleep 5
+    # Publish main crate
     {{ CMD }} publish --package medi-rs --allow-dirty {{ARGS}}
 
 check-format:

--- a/Justfile
+++ b/Justfile
@@ -19,8 +19,15 @@ build *ARGS='':
 # publish
 publish version='0.0.0' *ARGS='':
     echo "Building for release V{{ version }}"
-    sed -i 's/version = "[0-9.]*"$/version = "{{version}}"/' Cargo.toml
-    {{ CMD }} publish --allow-dirty {{ARGS}}
+    # Update version in root Cargo.toml
+    sed -i 's/^version = ".*"/version = "{{version}}"/' Cargo.toml
+    # Update version in src-macros/Cargo.toml
+    sed -i 's/^version = ".*"/version = "{{version}}"/' src-macros/Cargo.toml
+    # Update dependency version for medi-rs-macros in root Cargo.toml
+    sed -i 's/medi-rs-macros = { version *= *"[^"]*"/medi-rs-macros = { version = "{{version}}"/g' Cargo.toml
+
+    {{ CMD }} publish --package medi-rs-macros --allow-dirty {{ARGS}}
+    {{ CMD }} publish --package medi-rs --allow-dirty {{ARGS}}
 
 check-format:
     echo "Checking formatting..."
@@ -50,3 +57,4 @@ test:
 coverage:
     echo "Generating coverage..."
     {{ CMD }} llvm-cov --lcov --output-path lcov.info
+

--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ publish version='0.0.0' *ARGS='':
     # Update workspace version in [workspace.package] section
     sed -i '/^\[workspace\.package\]/,/^\[/ s/^version = ".*"/version = "{{version}}"/' Cargo.toml
     # Update dependency version for medi-rs-macros in root Cargo.toml to use published version
-    sed -i 's/medi-rs-macros = { path = "src-macros"/medi-rs-macros = { version = "{{version}}", path = "src-macros"/g' Cargo.toml
+    sed -i 's/medi-rs-macros = { version = "[^"]*", path = "src-macros"/medi-rs-macros = { version = "{{version}}", path = "src-macros"/g' Cargo.toml
 
     # Publish macro crate first
     {{ CMD }} publish --package medi-rs-macros --allow-dirty {{ARGS}}

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # medi-rs
 
-A flexible and lightweight mediator library for Rust, inspired by Axum’s handler function pattern. `medi-rs` provides a clean and effective approach to command and event handling in Rust applications, with dependency injection support.
+A flexible and lightweight mediator library for Rust, inspired by Axum's handler function pattern. `medi-rs` provides a clean and effective approach to command and event handling in Rust applications, with dependency injection support and powerful derive macros.
 
 ## Overview
 
@@ -16,20 +16,194 @@ A flexible and lightweight mediator library for Rust, inspired by Axum’s handl
   
 - **Event Handler**: Tailored for events. It receives a request but does not return a response or make the caller wait. Instead, it publishes the event to all designated handlers, allowing for efficient, non-blocking event processing.
 
-### Dependency Injection for Handlers
+### Derive Macros
 
-Handlers in `medi-rs` can be equipped with dependencies, simplifying access to shared resources. Use the `FromResource` trait to declare a struct as a dependency that can then be injected into handler functions. The maximum numerber of dependencies is 7.
+`medi-rs` provides convenient derive macros to reduce boilerplate code:
 
-#### Example
+#### `#[derive(MediCommand)]`
+
+Automatically implements the `IntoCommand` trait for command and query types. Supports specifying return types via attributes.
 
 ```rust
-#[derive(Debug)]
-struct MyResource;
+use medi_rs_macros::MediCommand;
 
-impl FromResource for MyResource {}
+// Command with default unit return type
+#[derive(MediCommand)]
+struct CreateUser {
+    name: String,
+}
 
-async fn handler(dep1: MyResource, req: Request) -> HandlerResult<()> {
-    // Handler logic here
+// Command with String return type
+#[derive(MediCommand)]
+#[medi_command(return_type = String)]
+struct GetGreeting {
+    name: String,
+}
+
+// Command with custom struct return type
+#[derive(MediCommand)]
+#[medi_command(return_type = UserInfo)]
+struct GetUserInfo {
+    id: u32,
+}
+
+struct UserInfo {
+    id: u32,
+    name: String,
+    email: String,
+}
+```
+
+#### `#[derive(MediEvent)]`
+
+Automatically implements the `IntoEvent` trait for event types.
+
+```rust
+use medi_rs_macros::MediEvent;
+
+#[derive(Clone, MediEvent)]
+struct UserCreated {
+    name: String,
+    email: String,
+}
+
+#[derive(Clone, MediEvent)]
+struct OrderProcessed {
+    order_id: u64,
+    total_amount: f64,
+}
+```
+
+#### `#[derive(MediRessource)]`
+
+Automatically implements the `FromResources` trait for dependency injection. Works with both simple and generic structs.
+
+```rust
+use medi_rs_macros::MediRessource;
+use std::sync::Arc;
+
+#[derive(Clone, MediRessource)]
+struct DatabaseConnection {
+    connection_string: String,
+}
+
+// Also works with generic structs
+#[derive(Clone, MediRessource)]
+struct Repository<T: UserRepository> {
+    inner: Arc<T>,
+}
+```
+
+### Dependency Injection for Handlers
+
+Handlers in `medi-rs` can be equipped with dependencies, simplifying access to shared resources. Use the `#[derive(MediRessource)]` macro to declare a struct as a dependency that can then be injected into handler functions. The maximum number of dependencies is 7.
+
+#### Complete Example
+
+```rust
+use medi_rs::{BusBuilder, Result};
+use medi_rs_macros::{MediCommand, MediRessource};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, MediRessource)]
+struct UserRepository {
+    users: Arc<Mutex<Vec<User>>>,
+}
+
+impl UserRepository {
+    fn new() -> Self {
+        Self {
+            users: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+    
+    fn save(&self, user: User) -> Result<()> {
+        self.users.lock().unwrap().push(user);
+        Ok(())
+    }
+}
+
+#[derive(MediCommand)]
+struct CreateUser {
+    name: String,
+}
+
+struct User {
+    name: String,
+}
+
+async fn handle_create_user(repo: UserRepository, req: CreateUser) -> Result<()> {
+    let user = User { name: req.name };
+    repo.save(user)?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let repo = UserRepository::new();
+    let bus = BusBuilder::default()
+        .add_req_handler(handle_create_user)
+        .append_resources(repo)
+        .build()?;
+
+    bus.send(CreateUser { name: "John".into() }).await?;
+    Ok(())
+}
+```
+
+### Event Handling Example
+
+```rust
+use medi_rs::{Bus, Result};
+use medi_rs_macros::{MediEvent, MediRessource};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, MediEvent)]
+struct UserRegistered {
+    user_id: u64,
+    email: String,
+}
+
+#[derive(Clone, MediRessource)]
+struct EmailService {
+    sent_emails: Arc<Mutex<Vec<String>>>,
+}
+
+async fn send_welcome_email(
+    email_service: EmailService,
+    event: UserRegistered,
+) -> Result<()> {
+    // Send welcome email logic
+    let email = format!("Welcome email sent to {}", event.email);
+    email_service.sent_emails.lock().unwrap().push(email);
+    Ok(())
+}
+
+async fn update_analytics(event: UserRegistered) -> Result<()> {
+    // Update analytics logic
+    println!("User {} registered in analytics", event.user_id);
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let email_service = EmailService {
+        sent_emails: Arc::new(Mutex::new(Vec::new())),
+    };
+    
+    let bus = Bus::builder()
+        .add_event_handler(send_welcome_email)
+        .add_event_handler(update_analytics)
+        .append_resources(email_service)
+        .build()?;
+
+    // Publish event - both handlers will be called
+    bus.publish(UserRegistered {
+        user_id: 123,
+        email: "user@example.com".into(),
+    }).await?;
+    
+    Ok(())
 }
 ```
 

--- a/src-macros/Cargo.toml
+++ b/src-macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "medi-rs-macros"
+version = "1.0.0"
+description = "A macro library for medi-rs"
+license = "MIT"
+homepage = "https://github.com/klab365/medi-rs"
+repository = "https://github.com/klab365/medi-rs"
+edition = "2024"
+
+[dependencies]
+quote = "1.0.40"
+syn = { version = "2.0.101", features = ["full"] }
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true
+
+[package.metadata.release]

--- a/src-macros/Cargo.toml
+++ b/src-macros/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "medi-rs-macros"
-version = "1.0.0"
 description = "A macro library for medi-rs"
-license = "MIT"
-homepage = "https://github.com/klab365/medi-rs"
-repository = "https://github.com/klab365/medi-rs"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+readme.workspace = true
 
 [dependencies]
 quote = "1.0.40"
@@ -16,5 +18,3 @@ workspace = true
 
 [lib]
 proc-macro = true
-
-[package.metadata.release]

--- a/src-macros/src/functions.rs
+++ b/src-macros/src/functions.rs
@@ -1,0 +1,79 @@
+use proc_macro::TokenStream;
+use syn::{Attribute, DeriveInput, Meta, Type, parse_macro_input, parse_quote};
+
+pub fn derive_medi_command_inner(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    // Look for #[medi_command(return_type = SomeType)] attribute
+    let return_type = extract_return_type(&input.attrs).unwrap_or_else(|| parse_quote!(()));
+
+    let expanded = quote::quote! {
+        impl #impl_generics IntoCommand<#return_type> for #name #ty_generics #where_clause {}
+    };
+
+    TokenStream::from(expanded)
+}
+
+fn extract_return_type(attrs: &[Attribute]) -> Option<Type> {
+    for attr in attrs {
+        if !attr.path().is_ident("medi_command") {
+            continue;
+        }
+
+        let Meta::List(meta_list) = &attr.meta else {
+            continue;
+        };
+
+        // Parse the attribute arguments manually from tokens
+        let tokens = &meta_list.tokens;
+        let tokens_str = tokens.to_string();
+
+        // Look for "return_type = TypeName" pattern (without quotes)
+        let Some(eq_pos) = tokens_str.find('=') else {
+            continue;
+        };
+
+        let key = tokens_str[..eq_pos].trim();
+        if key != "return_type" {
+            continue;
+        }
+
+        let type_str = tokens_str[eq_pos + 1..].trim();
+        // Parse the type string directly
+        if let Ok(ty) = syn::parse_str::<Type>(type_str) {
+            return Some(ty);
+        }
+    }
+    None
+}
+
+pub fn derive_medi_event_inner(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let expanded = quote::quote! {
+        impl #impl_generics IntoEvent for #name #ty_generics #where_clause {}
+    };
+
+    TokenStream::from(expanded)
+}
+
+pub fn derive_medi_ressource_inner(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let expanded = quote::quote! {
+        impl #impl_generics FromResources for #name #ty_generics #where_clause {}
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src-macros/src/lib.rs
+++ b/src-macros/src/lib.rs
@@ -1,0 +1,18 @@
+mod functions;
+
+use functions::{derive_medi_command_inner, derive_medi_event_inner, derive_medi_ressource_inner};
+
+#[proc_macro_derive(MediCommand, attributes(medi_command))]
+pub fn derive_medi_command(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_medi_command_inner(input)
+}
+
+#[proc_macro_derive(MediEvent)]
+pub fn derive_medi_event(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_medi_event_inner(input)
+}
+
+#[proc_macro_derive(MediRessource)]
+pub fn derive_medi_ressource(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    derive_medi_ressource_inner(input)
+}

--- a/src/bus/bus_builder.rs
+++ b/src/bus/bus_builder.rs
@@ -24,7 +24,7 @@ impl BusBuilder {
 
         if self.req_handlers.contains_key(&type_id) {
             let type_name = std::any::type_name::<Req>();
-            panic!("Route already exists for type: {}", type_name);
+            panic!("Handler already exists for type: {}", type_name);
         }
 
         self.req_handlers.insert(type_id, h.into_dyn());

--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -2,6 +2,7 @@ mod bus_builder;
 
 // -- flatten
 pub use bus_builder::BusBuilder;
+use medi_rs_macros::MediRessource;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 // -- use dependencies
@@ -14,15 +15,13 @@ use std::sync::Arc;
 
 type EventQueueItem = Box<dyn EventWrapperTrait + Send + Sync>;
 
-#[derive(Clone)]
+#[derive(Clone, MediRessource)]
 pub struct Bus {
     req_handlers: SharedHandler<Arc<dyn HandlerWrapperTrait>>,
     evt_handlers: SharedHandler<Vec<Arc<dyn HandlerWrapperTrait>>>,
     resources: Resources,
     pending_events: Sender<EventQueueItem>,
 }
-
-impl FromResources for Bus {}
 
 impl Bus {
     pub fn builder() -> BusBuilder {

--- a/src/handler/handler_wrapper.rs
+++ b/src/handler/handler_wrapper.rs
@@ -26,7 +26,7 @@ pub(crate) trait HandlerWrapperTrait: Send + Sync {
         &self,
         resources: Resources,
         value: Box<dyn Any + Send + Sync>,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<Box<dyn Any + Send + Sync>>> + Send + Sync>>;
+    ) -> Pin<Box<dyn futures::Future<Output = Result<Box<dyn Any + Send + Sync>>> + Send>>;
 }
 
 impl<H, TResource, Req, Res> HandlerWrapperTrait for HandlerWrapper<H, TResource, Req, Res>
@@ -40,7 +40,7 @@ where
         &self,
         resources: Resources,
         value: Box<dyn Any + Send + Sync>,
-    ) -> Pin<Box<dyn std::future::Future<Output = Result<Box<dyn Any + Send + Sync>>> + Send + Sync>> {
+    ) -> Pin<Box<dyn futures::Future<Output = Result<Box<dyn Any + Send + Sync>>> + Send>> {
         let Ok(arg) = value.downcast::<Req>() else {
             let type_name = std::any::type_name::<Req>();
             return Box::pin(async { Err(Error::CastError(type_name.to_string())) });
@@ -59,6 +59,8 @@ where
 mod tests {
     use std::sync::Arc;
 
+    use medi_rs_macros::MediCommand;
+
     use crate::IntoCommand;
 
     use super::*;
@@ -75,8 +77,8 @@ mod tests {
         assert!(matches!(res.unwrap_err(), Error::CastError(_)));
     }
 
+    #[derive(MediCommand)]
     struct BaseReq;
-    impl IntoCommand<()> for BaseReq {}
 
     async fn test_handler(_req: BaseReq) -> Result<()> {
         Ok(())

--- a/src/handler/macros.rs
+++ b/src/handler/macros.rs
@@ -3,14 +3,14 @@ macro_rules! impl_handler {
     ($($T:ident), *) => {
         impl<F, Fut, $($T,)* Req, Res, E> Handler<($($T,)*), Req, Res> for F
         where
-            F: FnOnce($($T,)* Req) -> Fut + Clone + Send + Sync + 'static,
+            F: FnOnce($($T,)* Req) -> Fut + Clone + Send + 'static,
             Req: Sync + Send + 'static,
             Res: Sync + Send + 'static,
             $($T: FromResources + Clone + Send + Sync + 'static,)*
             E: std::error::Error + Sized + Send + Sync + 'static,
-            Fut: std::future::Future<Output = core::result::Result<Res, E>> + Send + Sync + 'static,
+            Fut: futures::Future<Output = core::result::Result<Res, E>> + Send,
         {
-            type Future = std::pin::Pin<Box<dyn std::future::Future<Output = Result<Res>> + Send + Sync>>;
+            type Future = std::pin::Pin<Box<dyn futures::Future<Output = Result<Res>> + Send>>;
 
             #[allow(unused)]
             fn handle(self, resources: resource::Resources, value: Req) -> Self::Future {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -20,7 +20,7 @@ where
     Req: Send + Sync + 'static,
     Res: Send + Sync + 'static,
 {
-    type Future: std::future::Future<Output = Result<Res>> + Send + Sync + 'static;
+    type Future: futures::Future<Output = Result<Res>> + Send + 'static;
 
     fn handle(self, resources: Resources, value: Req) -> Self::Future;
 

--- a/tests/01_test_ping_pong_request_response.rs
+++ b/tests/01_test_ping_pong_request_response.rs
@@ -1,4 +1,5 @@
 use medi_rs::{BusBuilder, IntoCommand, Result};
+use medi_rs_macros::MediCommand;
 use std::sync::Arc;
 
 #[tokio::test]
@@ -52,8 +53,9 @@ async fn print_ping(id: Ping) -> Result<Pong> {
     Ok(Pong(format!("Pong: {}", id.0)))
 }
 
+#[derive(MediCommand)]
+#[medi_command(return_type = Pong)]
 struct Ping(String);
-impl IntoCommand<Pong> for Ping {}
 
 #[derive(Debug)]
 struct Pong(String);

--- a/tests/02_test_duration_request_response.rs
+++ b/tests/02_test_duration_request_response.rs
@@ -1,4 +1,5 @@
 use medi_rs::{BusBuilder, IntoCommand, Result};
+use medi_rs_macros::MediCommand;
 
 #[tokio::test]
 async fn send_should_take_less_than_1ms() {
@@ -18,5 +19,6 @@ async fn print_ping(ping: Ping) -> Result<String> {
     Ok(format!("Pong: {}", ping.0))
 }
 
+#[derive(MediCommand)]
+#[medi_command(return_type = String)]
 struct Ping(String);
-impl IntoCommand<String> for Ping {}

--- a/tests/03_test_request_with_resource.rs
+++ b/tests/03_test_request_with_resource.rs
@@ -1,6 +1,8 @@
 use medi_rs::BusBuilder;
 use medi_rs::FromResources;
 use medi_rs::{IntoCommand, Result};
+use medi_rs_macros::MediCommand;
+use medi_rs_macros::MediRessource;
 use std::sync::{Arc, Mutex};
 
 #[tokio::test]
@@ -21,11 +23,10 @@ async fn send_should_return_correct_value_from_the_resource() {
     assert_eq!(state[1], "world");
 }
 
-#[derive(Clone)]
+#[derive(Clone, MediRessource)]
 struct AppState {
     pub list: Arc<Mutex<Vec<String>>>,
 }
-impl FromResources for AppState {}
 
 impl AppState {
     pub fn new() -> Self {
@@ -40,5 +41,5 @@ async fn print_ping(state: AppState, req: Ping) -> Result<()> {
     Ok(())
 }
 
+#[derive(MediCommand)]
 struct Ping(String);
-impl IntoCommand<()> for Ping {}

--- a/tests/04_test_dependency_injection.rs
+++ b/tests/04_test_dependency_injection.rs
@@ -1,6 +1,7 @@
 use medi_rs::{
     BusBuilder, FromResources, {IntoCommand, Result},
 };
+use medi_rs_macros::{MediCommand, MediRessource};
 use std::sync::{Arc, Mutex};
 
 #[tokio::test]
@@ -50,10 +51,10 @@ async fn create_user_generic(state: AppStateGeneric<InMemoryUserRepository>, req
 }
 
 /// Request to create a user
+#[derive(MediCommand)]
 struct CreateUser {
     name: String,
 }
-impl IntoCommand<()> for CreateUser {}
 
 struct User {
     name: String,
@@ -79,7 +80,7 @@ impl UserRepository for InMemoryUserRepository {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, MediRessource)]
 struct AppStateDyn {
     user_repository: Arc<dyn UserRepository>,
 }
@@ -88,9 +89,8 @@ impl AppStateDyn {
         Self { user_repository }
     }
 }
-impl FromResources for AppStateDyn {}
 
-#[derive(Clone)]
+#[derive(Clone, MediRessource)]
 struct AppStateGeneric<T: UserRepository> {
     user_repository: Arc<T>,
 }
@@ -99,4 +99,3 @@ impl<T: UserRepository> AppStateGeneric<T> {
         Self { user_repository }
     }
 }
-impl<T: UserRepository> FromResources for AppStateGeneric<T> {}

--- a/tests/05_test_error_handling.rs
+++ b/tests/05_test_error_handling.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use medi_rs::{Bus, FromResources, IntoCommand};
-use std::sync::{Arc, Mutex};
+use medi_rs_macros::{MediCommand, MediRessource};
+use tokio::sync::Mutex;
 
 #[tokio::test]
 async fn send_should_return_error() {
@@ -57,18 +60,18 @@ async fn error_handler(_req: BasicRequest) -> Result<(), CustomError> {
     Err(CustomError::Basic("Error1".to_string()))
 }
 
-async fn error_handler1(_state: AppState, _req: BasicRequest) -> Result<(), CustomError> {
+async fn error_handler1(state: AppState, _req: BasicRequest) -> Result<(), CustomError> {
+    state.list.lock().await.push("test".to_string());
     Err(CustomError::Basic("Error2".to_string()))
 }
 
-#[derive(Debug, Clone)]
-struct AppState {
-    pub _list: Arc<Mutex<Vec<String>>>,
-}
-impl FromResources for AppState {}
-
+#[derive(MediCommand)]
 struct BasicRequest;
-impl IntoCommand<()> for BasicRequest {}
+
+#[derive(Debug, Clone, MediRessource)]
+pub struct AppState {
+    pub list: Arc<Mutex<Vec<String>>>,
+}
 
 #[derive(thiserror::Error, Debug)]
 enum CustomError {

--- a/tests/06_test_bus_as_resource.rs
+++ b/tests/06_test_bus_as_resource.rs
@@ -1,4 +1,5 @@
 use medi_rs::{Bus, IntoCommand, Result};
+use medi_rs_macros::MediCommand;
 
 #[tokio::test]
 async fn send_call_second_req_test() {
@@ -13,15 +14,15 @@ async fn send_call_second_req_test() {
     assert!(res.is_ok());
 }
 
+#[derive(MediCommand)]
 struct CreateUser {
     name: String,
 }
-impl IntoCommand<()> for CreateUser {}
 
+#[derive(MediCommand)]
 struct ValidateUser {
     name: String,
 }
-impl IntoCommand<()> for ValidateUser {}
 
 // handler functions...
 async fn create_user_dyn(bus: Bus, req: CreateUser) -> Result<()> {

--- a/tests/07_test_event.rs
+++ b/tests/07_test_event.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use medi_rs::{Bus, FromResources, IntoEvent, Result};
+use medi_rs_macros::{MediEvent, MediRessource};
 
 #[tokio::test]
 async fn publish_should_process_published_event() {
@@ -27,15 +28,14 @@ async fn publish_should_process_published_event() {
     assert!(res2.is_ok());
 }
 
-#[derive(Clone)]
+#[derive(Clone, MediEvent)]
 struct BaseEvent;
-impl IntoEvent for BaseEvent {}
 
 /// In-memory message queue for testing, if events are processed with the handlers
 /// The order is not so important, but the handlers should be called
-#[derive(Clone, Default)]
+#[derive(Clone, Default, MediRessource)]
 struct InMemoryMsgQueue(Arc<Mutex<Vec<String>>>);
-impl FromResources for InMemoryMsgQueue {}
+
 impl InMemoryMsgQueue {
     fn display_all(&self) {
         let queue = self.0.lock().unwrap();

--- a/tests/08_test_async_dependency.rs
+++ b/tests/08_test_async_dependency.rs
@@ -1,0 +1,85 @@
+use medi_rs::{Bus, BusBuilder, FromResources, IntoCommand, IntoEvent, Result};
+use medi_rs_macros::{MediCommand, MediEvent, MediRessource};
+use std::sync::{Arc, Mutex};
+
+#[tokio::test]
+async fn send_should_work_with_dependencyinjection() {
+    let repo = Arc::new(InMemoryUserRepository::new());
+    let state = AppStateDyn::new(repo.clone());
+    let bus = BusBuilder::default()
+        .add_req_handler(create_user_dyn)
+        .add_event_handler(user_created)
+        .append_resources(state.clone())
+        .build()
+        .unwrap();
+
+    bus.send(CreateUser { name: "John".into() }).await.unwrap();
+
+    let users = repo.0.lock().unwrap();
+    assert_eq!(users.len(), 1);
+    assert_eq!(users[0].name, "John");
+}
+
+async fn create_user_dyn(state: AppStateDyn, bus: Bus, req: CreateUser) -> Result<()> {
+    let user = User { name: req.name.clone() };
+    state.user_repository.save(user).await?;
+
+    let event = UserCreatedEvent { name: req.name };
+    bus.publish(event).await?;
+
+    Ok(())
+}
+
+async fn user_created(state: AppStateDyn, user: UserCreatedEvent) -> Result<()> {
+    // Here you could handle the event, e.g., log it or notify other services
+    println!("User created: {}", user.name);
+    state.user_repository.save(User { name: user.name }).await?;
+    Ok(())
+}
+
+/// Request to create a user
+#[derive(MediCommand)]
+struct CreateUser {
+    name: String,
+}
+
+#[derive(Clone, MediEvent)]
+struct UserCreatedEvent {
+    name: String,
+}
+
+struct User {
+    name: String,
+}
+
+#[async_trait::async_trait]
+trait UserRepository: Send + Sync {
+    async fn save(&self, user: User) -> Result<()>;
+}
+
+#[derive(Clone)]
+struct InMemoryUserRepository(Arc<Mutex<Vec<User>>>);
+
+impl InMemoryUserRepository {
+    pub fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+}
+
+#[async_trait::async_trait]
+impl UserRepository for InMemoryUserRepository {
+    async fn save(&self, user: User) -> Result<()> {
+        self.0.lock().unwrap().push(user);
+        Ok(())
+    }
+}
+
+#[derive(Clone, MediRessource)]
+struct AppStateDyn {
+    user_repository: Arc<dyn UserRepository>,
+}
+impl AppStateDyn {
+    pub fn new(user_repository: Arc<dyn UserRepository>) -> Self {
+        Self { user_repository }
+    }
+}

--- a/tests/09_test_command_return_types.rs
+++ b/tests/09_test_command_return_types.rs
@@ -1,0 +1,83 @@
+use medi_rs::{BusBuilder, IntoCommand, Result};
+use medi_rs_macros::MediCommand;
+
+#[tokio::test]
+async fn test_command_with_unit_return() {
+    let bus = BusBuilder::default()
+        .add_req_handler(handle_create_user)
+        .build()
+        .unwrap();
+
+    let result = bus.send(CreateUserCommand { _name: "John".into() }).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_command_with_string_return() {
+    let bus = BusBuilder::default()
+        .add_req_handler(handle_get_greeting)
+        .build()
+        .unwrap();
+
+    let result = bus.send(GetGreetingCommand { name: "John".into() }).await.unwrap();
+    assert_eq!(result, "Hello, John!");
+}
+
+#[tokio::test]
+async fn test_command_with_complex_return() {
+    let bus = BusBuilder::default()
+        .add_req_handler(handle_get_user_info)
+        .build()
+        .unwrap();
+
+    let result = bus.send(GetUserInfoCommand { id: 42 }).await.unwrap();
+    assert_eq!(result.id, 42);
+    assert_eq!(result.name, "User 42");
+    assert_eq!(result.age, 25);
+}
+
+// Command with default return type (unit)
+#[derive(MediCommand)]
+struct CreateUserCommand {
+    _name: String,
+}
+
+// Command with String return type
+#[derive(MediCommand)]
+#[medi_command(return_type = String)]
+struct GetGreetingCommand {
+    name: String,
+}
+
+// Command with custom struct return type
+#[derive(MediCommand)]
+#[medi_command(return_type = UserInfo)]
+struct GetUserInfoCommand {
+    id: u32,
+}
+
+#[derive(Debug, PartialEq)]
+struct UserInfo {
+    id: u32,
+    name: String,
+    age: u32,
+}
+
+// Handlers
+async fn handle_create_user(_req: CreateUserCommand) -> Result<()> {
+    // Simulate creating a user
+    println!("User created successfully");
+    Ok(())
+}
+
+async fn handle_get_greeting(req: GetGreetingCommand) -> Result<String> {
+    Ok(format!("Hello, {}!", req.name))
+}
+
+async fn handle_get_user_info(req: GetUserInfoCommand) -> Result<UserInfo> {
+    Ok(UserInfo {
+        id: req.id,
+        name: format!("User {}", req.id),
+        age: 25,
+    })
+}


### PR DESCRIPTION
…y support

- Update Rust version to 1.87.0 and add async-trait, futures dependencies
- Create new medi-rs-macros crate with derive macros for MediCommand, MediEvent, and MediRessource
- Implement async dependency injection with comprehensive test coverage
- Add command return type tests and enhance handler trait async support
- Update documentation and changelog for v1.2.0 release
- Integrate derive macros across modules and tests for improved ergonomics